### PR TITLE
Detail view working, still needs edits, created clickable link

### DIFF
--- a/Bangazon/Properties/launchSettings.json
+++ b/Bangazon/Properties/launchSettings.json
@@ -10,14 +10,13 @@
   "profiles": {
     "IIS Express": {
       "commandName": "IISExpress",
-      "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
     "Bangazon": {
       "commandName": "Project",
-      "launchBrowser": false,
+      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/Bangazon/Views/Products/Index.cshtml
+++ b/Bangazon/Views/Products/Index.cshtml
@@ -52,7 +52,7 @@
                 @Html.DisplayFor(modelItem => item.Description)
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.Title)
+                <a href=@($"http://localhost:5000/Products/Details/{item.ProductId}")>@Html.DisplayFor(modelItem => item.Title)</a> 
             </td>
             <td>
                 @Html.DisplayFor(modelItem => item.Price)


### PR DESCRIPTION
Fixes:
no current fixes

Changes proposed in this request & reasons behind organizational or architectural decisions:
Details page now displays date created, description, title, price, quantity, city, and product type. The edit and index hyperlinks have been removed. Working details title links can also be found on the products page. 

Steps to test:
git fetch --all
checkout to BranchMo
git pull origin BranchMo
Run program
Naviagate to Products/Details/*id of item you want to see*

Additionally, navigate to /Products
All titles should be hyperlinks that go to the details view

System configuration (3rd party libraries to be installed, command line utilities to run, UI instructions, expected outcome):

none


Link to feature ticket:
https://github.com/nss-day-cohort-30/bangazon-site-suave-salmon/issues/1

@suave-salmon
