### PR TITLE
Fixing detail link

### DIFF
--- a/Bangazon/Views/Products/Details.cshtml
+++ b/Bangazon/Views/Products/Details.cshtml
@@ -47,11 +47,11 @@
             @Html.DisplayFor(model => model.City)
         </dd>
   
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.ProductType)
+        <dt class="col-sm-2">
+
         </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.ProductType.Label)
+        <dd class="col-sm-10">
+            <a href=@($"http://localhost:5000/Products/GetProductsByCategory/{Model.ProductTypeId}")>@Html.DisplayFor(modelItem => Model.ProductType.Label)</a>
         </dd>
     </dl>
 </div>

--- a/Bangazon/Views/Products/Types.cshtml
+++ b/Bangazon/Views/Products/Types.cshtml
@@ -25,7 +25,7 @@
         {
             <tr>
                 <td>
-                    <a href=@($"http://localhost:5000/Products/GetProductsByCategory/{item.TypeId}")>@Html.DisplayFor(modelItem => item.TypeName)</a>
+                    <h2><a href=@($"http://localhost:5000/Products/GetProductsByCategory/{item.TypeId}")>@Html.DisplayFor(modelItem => item.TypeName)</a></h2>
                 </td>
                 <td>
                     @Html.DisplayFor(modelItem => item.ProductCount)


### PR DESCRIPTION
Fixes:
Fixed the product type on detail view to be a link. Added H2 to product category list

Changes proposed in this request & reasons behind organizational or architectural decisions:
Links required by ticket. H2s were added for clarity

Steps to test:
git fetch --all
checkout to FixingDetailLink 
git pull origin FixingDetailLink
Run program
Naviagate to Products/Details/*id of item you want to see* and check that the product type is clickable

Additionally, navigate to product types to view h2

System configuration (3rd party libraries to be installed, command line utilities to run, UI instructions, expected outcome):

none


Link to feature ticket:

https://github.com/nss-day-cohort-30/bangazon-site-suave-salmon/issues/1suave-salmon
