### PR TITLE
delete payment type

### DIFF
--- a/Bangazon/Controllers/PaymentTypesController.cs
+++ b/Bangazon/Controllers/PaymentTypesController.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore;
 using Bangazon.Data;
 using Bangazon.Models;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Bangazon.Controllers
 {
@@ -25,13 +26,20 @@ namespace Bangazon.Controllers
         private Task<ApplicationUser> GetCurrentUserAsync() => _userManager.GetUserAsync(HttpContext.User);
 
         // GET: PaymentTypes
+        [Authorize]
         public async Task<IActionResult> Index()
         {
-            var applicationDbContext = _context.PaymentType.Include(p => p.User);
+            var user = await GetCurrentUserAsync();
+
+            var applicationDbContext = _context.PaymentType
+                .Include(p => p.User)
+                .Where(p => p.User.Id == user.Id)
+                ;
             return View(await applicationDbContext.ToListAsync());
         }
 
         // GET: PaymentTypes/Details/5
+        [Authorize]
         public async Task<IActionResult> Details(int? id)
         {
             if (id == null)

--- a/Bangazon/Views/PaymentTypes/Delete.cshtml
+++ b/Bangazon/Views/PaymentTypes/Delete.cshtml
@@ -29,12 +29,6 @@
         <dd class = "col-sm-10">
             @Html.DisplayFor(model => model.AccountNumber)
         </dd>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.User)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.User.Id)
-        </dd class>
     </dl>
     
     <form asp-action="Delete">

--- a/Bangazon/Views/PaymentTypes/Index.cshtml
+++ b/Bangazon/Views/PaymentTypes/Index.cshtml
@@ -21,9 +21,6 @@
             <th>
                 @Html.DisplayNameFor(model => model.AccountNumber)
             </th>
-            <th>
-                @Html.DisplayNameFor(model => model.User)
-            </th>
             <th></th>
         </tr>
     </thead>
@@ -40,11 +37,8 @@
                 @Html.DisplayFor(modelItem => item.AccountNumber)
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.User.Id)
-            </td>
-            <td>
-                <a asp-action="Edit" asp-route-id="@item.PaymentTypeId">Edit</a> |
-                <a asp-action="Details" asp-route-id="@item.PaymentTypeId">Details</a> |
+                @*<a asp-action="Edit" asp-route-id="@item.PaymentTypeId">Edit</a> |*@
+                @*<a asp-action="Details" asp-route-id="@item.PaymentTypeId">Details</a> |*@
                 <a asp-action="Delete" asp-route-id="@item.PaymentTypeId">Delete</a>
             </td>
         </tr>


### PR DESCRIPTION
Changes proposed in this request & reasons behind organizational or architectural decisions:
- Users can only view their own payment types and must be logged in to do so
- Users can delete payment types

Steps to test:
- git fetch --all
- checkout kc-branch
- run program
- go to localhost:5000/paymenttypes
- you should not see any payment types unless logged in, and you should only see payment types associated with the logged in user
- delete a payment type

Commit message:
- delete payment type

Link to feature ticket:
- [#7](https://github.com/nss-day-cohort-30/bangazon-site-suave-salmon/issues/7)

@suave-salmon
